### PR TITLE
Fixed issue with stale / missing kernel-devel headers

### DIFF
--- a/ltcminers.yml
+++ b/ltcminers.yml
@@ -13,6 +13,9 @@
   - name: setup development tools
     yum: name="@Development tools" state=present
     sudo: yes
+  - name: setup latest kernel headers
+    shell: yum -y install kernel-devel-`uname -r`
+    sudo: yes
   - name: setup cuda packages
     command: yum -y install git libcurl-devel python-devel screen rsync yasm numpy openssl-devel
     sudo: yes


### PR DESCRIPTION
Stale / missing kernel-devel headers were causing the CUDA install to abort.

Fixes #3 
